### PR TITLE
Follow the Freedesktop spec for thumbnails location

### DIFF
--- a/src/Thumbview.cc
+++ b/src/Thumbview.cc
@@ -427,7 +427,7 @@ Glib::ustring Thumbview::cache_file(Glib::ustring file) {
 	delete [] full;
 
 	// build dir paths
-	Glib::ustring halfref = Glib::build_filename(Glib::get_home_dir(),".thumbnails/");
+	Glib::ustring halfref = Glib::build_filename(Glib::get_user_cache_dir(),"thumbnails/");
 	halfref = Glib::build_filename(halfref, "normal/");
 
 	if ( !Glib::file_test(halfref, Glib::FILE_TEST_EXISTS) )


### PR DESCRIPTION
According to the [Freedesktop specifications for thumbnails](http://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html#DIRECTORY), the thumbnails directory should be stored in `$XDG_CACHE_HOME/thumbnails`, not in `$HOME/.thumbnails`. This fixes that.
