### PR TITLE
add warnings for packagers

### DIFF
--- a/README
+++ b/README
@@ -21,7 +21,8 @@ BUILDING:
           CXXFLAGS="-O2" ./configure
     
           PACKAGERS: Make sure you set CXXFLAGS to an appropriate value for
-          the target system.
+          the target system. For instance, CXXFLAGS=" -std=c++11" if using 
+          gcc 5.x.
 
 USAGE:
     See the man page. It *might* be up to date.


### PR DESCRIPTION
I've got noticed that I need to set CXXFLAGS=" -std=c++11" or CXXFLAGS=" -std=gnu++11" using gcc5. So i think it's not a bad idea to mention in README.