### PR TITLE
LXDE (Pcmanfm) support (WIP)

### DIFF
--- a/src/ArgParser.cc
+++ b/src/ArgParser.cc
@@ -24,11 +24,20 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 bool ArgParser::parse
 			(int argc, char ** argv) {
-	int count = 1;
+    std::vector<Glib::ustring> argVec;
+    for (int i = 0; i < argc; i++) {
+        argVec.push_back(Glib::ustring(argv[i]));
+    }
+
+    return this->parse(argVec);
+}
+
+bool ArgParser::parse
+            (std::vector<Glib::ustring> argVec) {
 	bool retval = true;
 
-	while (count < argc) {
-		std::string arg (argv[count++]);
+    for (std::vector<Glib::ustring>::const_iterator i = argVec.begin() + 1; i != argVec.end(); i++) {
+		std::string arg(*i);
 		std::string key = arg;
 		std::string value;
 

--- a/src/ArgParser.h
+++ b/src/ArgParser.h
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <vector>
 #include <sstream>
 #include <iostream>
+#include <glibmm.h>
 
 class Arg {
 	public:
@@ -120,6 +121,7 @@ class ArgParser {
 
 		// parses away.
 		bool parse (int argc, char ** argv);
+        bool parse (std::vector<Glib::ustring> argVec);
 
 		// returns the help text (--help)
 		std::string help_text (void) const;

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "Config.h"
 #include <glib/gstdio.h>
 #include "gcs-i18n.h"
+#include "Util.h"
 
 /**
  * Constructor, initializes default settings.
@@ -250,7 +251,7 @@ bool Config::set_bg(const Glib::ustring disp, const Glib::ustring file, const Se
 	// set data
 	g_key_file_set_string(kf, realdisp.c_str(), "file", file.c_str());
 	g_key_file_set_integer(kf, realdisp.c_str(), "mode", (gint)mode);
-	g_key_file_set_string(kf, realdisp.c_str(), "bgcolor", color_to_string(bgcolor).c_str());
+	g_key_file_set_string(kf, realdisp.c_str(), "bgcolor", Util::color_to_string(bgcolor).c_str());
 
 	// output it
 	Glib::ustring outp = g_key_file_to_data(kf, NULL, NULL);
@@ -314,26 +315,6 @@ bool Config::check_dir() {
 			return false;
 
 	return true;
-}
-
-/**
- * Converts a Gdk::Color to a string representation with a #.
- *
- * @param	color	The color to convert
- * @return			A hex string
- */
-Glib::ustring Config::color_to_string(Gdk::Color color) {
-	guchar red = guchar(color.get_red_p() * 255);
-	guchar green = guchar(color.get_green_p() * 255);
-	guchar blue = guchar(color.get_blue_p() * 255);
-
-	char * c_str = new char[7];
-
-	snprintf(c_str, 7, "%.2x%.2x%.2x", red, green, blue);
-	Glib::ustring string = '#' + Glib::ustring(c_str);
-
-	delete[] c_str;
-	return string;
 }
 
 /**

--- a/src/Config.h
+++ b/src/Config.h
@@ -46,8 +46,6 @@ class Config {
         VecStrs m_vec_dirs;
 	Thumbview::SortMode m_sort_mode;
 
-		Glib::ustring color_to_string(Gdk::Color color);
-
         std::string get_bg_config_file() const { return get_file("bg-saved.cfg"); }
         std::string get_config_file() const { return get_file("nitrogen.cfg"); }
         std::string get_file(const Glib::ustring filename) const;

--- a/src/NWindow.h
+++ b/src/NWindow.h
@@ -43,7 +43,7 @@ class NWindow : public Gtk::Window {
         std::map<Glib::ustring, Glib::ustring> map_displays;        // a map of current displays on the running instance to their display names
         void set_default_display(int display);
 
-        void set_bg(Glib::ustring file);
+        bool set_bg(Glib::ustring file);
 
     protected:
         Glib::RefPtr<Gtk::ActionGroup> m_action_group;

--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -199,6 +199,7 @@ SetBG::RootWindowType SetBG::get_rootwindowtype(Glib::RefPtr<Gdk::Display> displ
                     if (strclass == std::string("Xfdesktop")) retval = SetBG::XFCE;     else
                     if (strclass == std::string("Nautilus"))  retval = SetBG::NAUTILUS; else
                     if (strclass == std::string("Nemo"))      retval = SetBG::NEMO;     else
+                    if (strclass == std::string("Pcmanfm"))   retval = SetBG::PCMANFM;  else
                     {
                         std::cerr << _("UNKNOWN ROOT WINDOW TYPE DETECTED, will attempt to set via normal X procedure") << "\n";
                         retval = SetBG::UNKNOWN;

--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -1404,6 +1404,9 @@ bool SetBGPcmanfm::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode,
                 kf.set_string("*", "wallpaper0", file);
                 kf.set_string("*", "desktop_bg", Util::color_to_string(bgcolor));
 
+                if (kf.has_key("*", "wallpaper"))
+                    kf.remove_key("*", "wallpaper");
+
                 kf.save_to_file(configfile);
             }
 

--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -61,6 +61,9 @@ SetBG* SetBG::get_bg_setter()
             ((SetBGXinerama*)setter)->set_xinerama_info(xinerama_info, xinerama_num_screens);
             break;
 #endif
+        case SetBG::PCMANFM:
+            setter = new SetBGPcmanfm();
+            break;
         case SetBG::DEFAULT:
         default:
             setter = new SetBGXWindows();
@@ -1262,6 +1265,20 @@ bool SetBGPcmanfm::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode,
     vecCmdLine.push_back(std::string("--wallpaper-mode"));
     vecCmdLine.push_back(strmode);
 
+    try {
+        Glib::spawn_async("", vecCmdLine, Glib::SPAWN_SEARCH_PATH);
+    }
+    catch (Glib::SpawnError e)
+    {
+        std::cerr << _("ERROR") << "\n" << e.what() << "\n";
+
+        for (std::vector<std::string>::const_iterator i = vecCmdLine.begin(); i != vecCmdLine.end(); i++)
+            std::cerr << *i << " ";
+
+        std::cerr << "\n";
+
+        return false;
+    }
 
     return true;
 }

--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -937,6 +937,16 @@ void SetBG::disable_pixmap_save()
     has_set_once = true;
 }
 
+/**
+ * Returns if this background setter should be setting the Nitrogen configuration.
+ *
+ * Override this in alternate setters that may directly touch external configurations.
+ */
+bool SetBG::save_to_config()
+{
+    return true;
+}
+
 /*
  * **************************************************************************
  * SetBGXwindows
@@ -1231,6 +1241,16 @@ void SetBGGnome::set_show_desktop()
     settings->set_boolean("draw-background", true);
 }
 
+/**
+ * Returns if this background setter should be setting the Nitrogen configuration.
+ *
+ * The Gnome mode is completely external.
+ */
+bool SetBGGnome::save_to_config()
+{
+    return false;
+}
+
 /*
  * **************************************************************************
  * SetBGNemo
@@ -1256,6 +1276,16 @@ void SetBGNemo::set_show_desktop()
 {
     Glib::RefPtr<Gio::Settings> settings = Gio::Settings::create(Glib::ustring("org.nemo.desktop"));
     settings->set_boolean("draw-background", true);
+}
+
+/**
+ * Returns if this background setter should be setting the Nitrogen configuration.
+ *
+ * The Nemo mode is completely external.
+ */
+bool SetBGNemo::save_to_config()
+{
+    return false;
 }
 
 /*
@@ -1464,5 +1494,15 @@ Glib::ustring SetBGPcmanfm::get_fullscreen_key() {
  */
 Glib::ustring SetBGPcmanfm::make_display_key(gint head) {
     return Glib::ustring::compose("%1", head);
+}
+
+/**
+ * Returns if this background setter should be setting the Nitrogen configuration.
+ *
+ * The Pcmanfm mode is completely external.
+ */
+bool SetBGPcmanfm::save_to_config()
+{
+    return false;
 }
 

--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -1235,3 +1235,41 @@ void SetBGNemo::set_show_desktop()
     Glib::RefPtr<Gio::Settings> settings = Gio::Settings::create(Glib::ustring("org.nemo.desktop"));
     settings->set_boolean("draw-background", true);
 }
+
+/*
+ * **************************************************************************
+ * SetBGPcmanfm
+ * **************************************************************************
+ */
+
+bool SetBGPcmanfm::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode, Gdk::Color bgcolor)
+{
+    Glib::ustring strmode;
+    switch(mode) {
+        case SetBG::SET_SCALE:      strmode = "stretch";  break;
+        case SetBG::SET_TILE:       strmode = "tile"; break;
+        case SetBG::SET_CENTER:     strmode = "center"; break;
+        case SetBG::SET_ZOOM:       strmode = "screen"; break;
+        case SetBG::SET_ZOOM_FILL:  strmode = "crop"; break;
+        default:                    strmode = "fit"; break;
+	};
+
+    std::vector<std::string> vecCmdLine;
+
+    vecCmdLine.push_back(std::string("pcmanfm"));
+    vecCmdLine.push_back(std::string("--set-wallpaper"));
+    vecCmdLine.push_back(file);
+    vecCmdLine.push_back(std::string("--wallpaper-mode"));
+    vecCmdLine.push_back(strmode);
+
+
+    return true;
+}
+
+std::map<Glib::ustring, Glib::ustring> SetBGPcmanfm::get_active_displays()
+{
+    std::map<Glib::ustring, Glib::ustring> map_displays;
+    map_displays["dummy"] = "Pcmanfm";
+    return map_displays;
+}
+

--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -1303,8 +1303,7 @@ bool SetBGPcmanfm::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode,
                                         False, XA_CARDINAL, &ret_type, &ret_format, &ret_items, &ret_bytesleft, &data);
 
         if (result != Success) {
-            // throw?
-            throw false;
+            std::cerr << "ERROR: Could not determine pid of Pcmanfm desktop window, is _NET_WM_PID set on X root window?\n";
             return false;
         }
 
@@ -1413,13 +1412,21 @@ bool SetBGPcmanfm::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode,
             // send USR1 to pcmanfm
             kill(pid, SIGUSR1);
         } else {
-            throw "failboat";
+            std::cerr << "ERROR: _NET_WM_PID set on X root window, but pid not readable.\n";
+            return false;
         }
     }
 
     return true;
 }
 
+/**
+ * Gets all active screens on this display.
+ * This is used by the main window to determine what to show in the dropdown,
+ * if anything.
+ *
+ * Returns a map of display string to human-readable representation.
+ */
 std::map<Glib::ustring, Glib::ustring> SetBGPcmanfm::get_active_displays()
 {
     Glib::RefPtr<Gdk::Display> disp = Gdk::DisplayManager::get()->get_default_display();

--- a/src/SetBG.h
+++ b/src/SetBG.h
@@ -57,6 +57,7 @@ class SetBG {
             UNKNOWN,
             XINERAMA,
             NEMO,
+            PCMANFM,
         };
 
 		virtual bool set_bg(Glib::ustring &disp,

--- a/src/SetBG.h
+++ b/src/SetBG.h
@@ -167,4 +167,14 @@ class SetBGNemo : public SetBGGnome {
         virtual void set_show_desktop();
 };
 
+class SetBGPcmanfm : public SetBGGnome {
+    public:
+		virtual bool set_bg(Glib::ustring &disp,
+                            Glib::ustring file,
+                            SetMode mode,
+                            Gdk::Color bgcolor);
+
+        virtual std::map<Glib::ustring, Glib::ustring> get_active_displays();
+};
+
 #endif

--- a/src/SetBG.h
+++ b/src/SetBG.h
@@ -98,6 +98,7 @@ class SetBG {
 
         static int handle_x_errors(Display *display, XErrorEvent *error);
         static int find_desktop_window(Display *display, Window curwindow);
+        static guint get_root_window(Glib::RefPtr<Gdk::Display> display);
 
         Glib::RefPtr<Gdk::Pixbuf> make_resized_pixbuf(Glib::RefPtr<Gdk::Pixbuf> pixbuf, SetBG::SetMode mode, Gdk::Color bgcolor, gint tarw, gint tarh);
         virtual Glib::RefPtr<Gdk::Display> get_display(const Glib::ustring& disp);

--- a/src/SetBG.h
+++ b/src/SetBG.h
@@ -83,6 +83,8 @@ class SetBG {
         void reset_first_pixmaps();
         void disable_pixmap_save();
 
+        virtual bool save_to_config();
+
 	protected:
 
         virtual Glib::ustring get_prefix() = 0;
@@ -155,6 +157,7 @@ class SetBGGnome : public SetBG {
 
         virtual std::map<Glib::ustring, Glib::ustring> get_active_displays();
         virtual Glib::ustring get_fullscreen_key();
+        virtual bool save_to_config();
     protected:
         virtual Glib::ustring get_prefix();
         virtual Glib::ustring make_display_key(gint head);
@@ -163,6 +166,8 @@ class SetBGGnome : public SetBG {
 };
 
 class SetBGNemo : public SetBGGnome {
+    public:
+        virtual bool save_to_config();
     protected:
         virtual Glib::ustring get_gsettings_key();
         virtual void set_show_desktop();
@@ -177,6 +182,7 @@ class SetBGPcmanfm : public SetBGGnome {
                             Gdk::Color bgcolor);
 
         virtual std::map<Glib::ustring, Glib::ustring> get_active_displays();
+        virtual bool save_to_config();
     protected:
         virtual Glib::ustring make_display_key(gint head);
 };

--- a/src/SetBG.h
+++ b/src/SetBG.h
@@ -170,12 +170,15 @@ class SetBGNemo : public SetBGGnome {
 
 class SetBGPcmanfm : public SetBGGnome {
     public:
+        virtual Glib::ustring get_fullscreen_key();
 		virtual bool set_bg(Glib::ustring &disp,
                             Glib::ustring file,
                             SetMode mode,
                             Gdk::Color bgcolor);
 
         virtual std::map<Glib::ustring, Glib::ustring> get_active_displays();
+    protected:
+        virtual Glib::ustring make_display_key(gint head);
 };
 
 #endif

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -97,7 +97,7 @@ ArgParser* create_arg_parser() {
     parser->register_option("sort", _("How to sort the backgrounds. Valid options are:\n\t\t\t* alpha, for alphanumeric sort\n\t\t\t* ralpha, for reverse alphanumeric sort\n\t\t\t* time, for last modified time sort (oldest first)\n\t\t\t* rtime, for reverse last modified time sort (newest first)"), true);
     parser->register_option("set-color", _("background color in hex, #000000 by default"), true);
     parser->register_option("head", _("Select xinerama/multihead display in GUI, 0..n, -1 for full"), true);
-    parser->register_option("force-setter", _("Force setter engine: xwindows, xinerama, gnome"), true);
+    parser->register_option("force-setter", _("Force setter engine: xwindows, xinerama, gnome, pcmanfm"), true);
     parser->register_option("random", _("Choose random background from config or given directory"));
 
     // command line set modes

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -297,4 +297,24 @@ Glib::ustring make_current_set_string(Gtk::Window* window, Glib::ustring filenam
     return ostr.str();
 }
 
+/**
+ * Converts a Gdk::Color to a string representation with a #.
+ *
+ * @param	color	The color to convert
+ * @return			A hex string
+ */
+Glib::ustring color_to_string(Gdk::Color color) {
+	guchar red = guchar(color.get_red_p() * 255);
+	guchar green = guchar(color.get_green_p() * 255);
+	guchar blue = guchar(color.get_blue_p() * 255);
+
+	char * c_str = new char[7];
+
+	snprintf(c_str, 7, "%.2x%.2x%.2x", red, green, blue);
+	Glib::ustring string = '#' + Glib::ustring(c_str);
+
+	delete[] c_str;
+	return string;
+}
+
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -40,6 +40,8 @@ namespace Util {
 
     bool is_display_relevant(Gtk::Window* window, Glib::ustring display);
     Glib::ustring make_current_set_string(Gtk::Window* window, Glib::ustring filename, Glib::ustring display);
+
+    Glib::ustring color_to_string(Gdk::Color color);
 }
 
 #endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -72,9 +72,11 @@ int set_bg_once(Config *cfg, SetBG* bg_setter, Glib::ustring path, int head, Set
     bg_setter->disable_pixmap_save();
 
     disp = bg_setter->make_display_key(head);
-    bg_setter->set_bg(disp, file, mode, col);
+    bool shouldSave = bg_setter->set_bg(disp, file, mode, col);
 
-	if (save) Config::get_instance()->set_bg(disp, file, mode, col);
+	if (save && shouldSave)
+        Config::get_instance()->set_bg(disp, file, mode, col);
+
 	while (Gtk::Main::events_pending())
 		Gtk::Main::iteration();
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -156,6 +156,8 @@ int main (int argc, char ** argv) {
         }
         else if (setter_str == "gnome")
             setter = new SetBGGnome();
+        else if (setter_str == "pcmanfm")
+            setter = new SetBGPcmanfm();
         else
             setter = SetBG::get_bg_setter();
 


### PR DESCRIPTION
Fixes #63 

Adding setter backend for Pcmanfm (aka what LXDE uses).  

TODO:
- [x] Clean up exception pathways
- [x] Make sure Currently Set strings in UI make sense
- [x] Don't prompt for saving/dirty flag
- [ ] Make sure configs don't crash pcmanfm!

Since Pcmanfm's command line switch can't take a monitor parameter in any way, it always defaults to monitor 0, which means Nitrogen can't control the other heads as appropriate.  Therefore, we directly manipulate the Pcmanfm desktop configuration files and send it a `SIGUSR1` which seems to reload it.  I'm not sure this is an incredibly stable approach, though.