### PR TITLE
Fix compile failure with --disable-xinerama

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -146,6 +146,7 @@ int main (int argc, char ** argv) {
 
         if (setter_str == "xwindows")
             setter = new SetBGXWindows();
+#ifdef USE_XINERAMA
         else if (setter_str == "xinerama") {
             setter = new SetBGXinerama();
 
@@ -156,6 +157,7 @@ int main (int argc, char ** argv) {
             xinerama_info = XineramaQueryScreens(GDK_DISPLAY_XDISPLAY(dpy->gobj()), &xinerama_num_screens);
             ((SetBGXinerama*)setter)->set_xinerama_info(xinerama_info, xinerama_num_screens);
         }
+#endif /* USE_XINERAMA */
         else if (setter_str == "gnome")
             setter = new SetBGGnome();
         else if (setter_str == "pcmanfm")


### PR DESCRIPTION
```
main.cc: In function ‘int set_bg_once(Config*, SetBG*, Glib::ustring, int, SetBG::SetMode, bool, Gdk::Color, bool)’:
main.cc:49:40: warning: left operand of comma operator is a reference, not call, to function ‘Glib::file_test’ [-Waddress]
             if (Glib::file_test, Glib::FILE_TEST_IS_DIR) {
                                        ^
main.cc:49:40: warning: left operand of comma operator has no effect [-Wunused-value]
main.cc: In function ‘int main(int, char**)’:
main.cc:150:26: error: expected type-specifier before ‘SetBGXinerama’
             setter = new SetBGXinerama();
                          ^
main.cc:152:13: error: ‘XineramaScreenInfo’ was not declared in this scope
             XineramaScreenInfo *xinerama_info;
             ^
main.cc:152:33: error: ‘xinerama_info’ was not declared in this scope
             XineramaScreenInfo *xinerama_info;
                                 ^
main.cc:156:106: error: ‘XineramaQueryScreens’ was not declared in this scope
          xinerama_info = XineramaQueryScreens(GDK_DISPLAY_XDISPLAY(dpy->gobj()), &xinerama_num_screens);
                                                                                                       ^
main.cc:157:15: error: ‘SetBGXinerama’ was not declared in this scope
             ((SetBGXinerama*)setter)->set_xinerama_info(xinerama_info, xinerama_num_screens);
               ^
main.cc:157:29: error: expected primary-expression before ‘)’ token
             ((SetBGXinerama*)setter)->set_xinerama_info(xinerama_info, xinerama_num_screens);
                             ^
main.cc:157:30: error: expected ‘)’ before ‘setter’
             ((SetBGXinerama*)setter)->set_xinerama_info(xinerama_info, xinerama_num_screens);
                              ^
```