### PR TITLE
Fix Issue with Replacing Config File Symlinks

### DIFF
--- a/src/Config.cc
+++ b/src/Config.cc
@@ -393,8 +393,10 @@ bool Config::save_cfg()
 
     kf.set_string_list("nitrogen", "dirs", m_vec_dirs);
 
-    if (g_file_set_contents(cfgfile.c_str(), kf.to_data().c_str(), -1, NULL) == FALSE)
-        return false;
+    Glib::ustring outp = kf.to_data();
+    std::ofstream outf(cfgfile.c_str());
+    outf << outp;
+    outf.close();
 
     return true;
 }


### PR DESCRIPTION
Replace writing the configu fileo through GLib and use an output file stream
which will automatically reference the symlink. This is the same behavior used
when writing the background file.

fixes #113