### PR TITLE
XFCE Setter

### DIFF
--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -1607,6 +1607,13 @@ bool SetBGXFCE::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode, Gd
         // sets it on monitor0.  just tweak the params here and continue
         disp    = std::string("0");
         strmode = std::string("6");
+    } else {
+        // special checking: make sure it's in active displays, or we'll accidentally set brand new keys
+        std::map<Glib::ustring, Glib::ustring> active_displays = this->get_active_displays();
+        if (active_displays.find(disp) == active_displays.end()) {
+            std::cerr << Glib::ustring::compose("Unknown display value (%1) for XFCE", disp) << "\n";
+            return false;
+        }
     }
 
     // set image

--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -66,6 +66,9 @@ SetBG* SetBG::get_bg_setter()
         case SetBG::PCMANFM:
             setter = new SetBGPcmanfm();
             break;
+        case SetBG::XFCE:
+            setter = new SetBGXFCE();
+            break;
         case SetBG::DEFAULT:
         default:
             setter = new SetBGXWindows();
@@ -1563,6 +1566,90 @@ Glib::ustring SetBGPcmanfm::make_display_key(gint head) {
  * The Pcmanfm mode is completely external.
  */
 bool SetBGPcmanfm::save_to_config()
+{
+    return false;
+}
+
+/*
+ * **************************************************************************
+ * SetBGXFCE
+ * **************************************************************************
+ */
+
+bool SetBGXFCE::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode, Gdk::Color bgcolor) {
+    Glib::ustring strmode = "1"; //centered
+	switch(mode) {
+		case SetBG::SET_CENTER:     strmode = "1"; break;
+		case SetBG::SET_TILE:       strmode = "2"; break;
+		case SetBG::SET_SCALE:      strmode = "3"; break;   // xfce calls this "stretched"
+		case SetBG::SET_ZOOM:       strmode = "4"; break;   // xfce calls this "scaled"
+		case SetBG::SET_ZOOM_FILL:  strmode = "5"; break;   // xfce calls this "zoomed"
+	};
+
+    std::vector<std::string> vecCmdLine;
+    vecCmdLine.push_back(std::string("xfconf-query"));
+    vecCmdLine.push_back(std::string("-c"));
+    vecCmdLine.push_back(std::string("xfce4-desktop"));
+    vecCmdLine.push_back(std::string("-p"));
+    vecCmdLine.push_back(std::string("/backdrop/screen0/monitor0/workspace0/last-image"));  // XXX: monitor
+    vecCmdLine.push_back(std::string("-s"));
+    vecCmdLine.push_back(std::string(file));
+
+    try {
+        Glib::spawn_async("", vecCmdLine, Glib::SPAWN_SEARCH_PATH);
+    }
+    catch (Glib::SpawnError e) {
+		std::cerr << _("ERROR") << "\n" << e.what() << "\n";
+
+        for (std::vector<std::string>::const_iterator i = vecCmdLine.begin(); i != vecCmdLine.end(); i++)
+			std::cerr << *i << " ";
+
+		std::cerr << "\n";
+
+        return false;
+	}
+
+	return true;
+}
+
+Glib::ustring SetBGXFCE::make_display_key(gint head)
+{
+    //if (head == -1)
+    //    return this->get_fullscreen_key();
+
+    //return Glib::ustring::compose("monitor%1/workspace%2", this->get_prefix(), head);
+    return Glib::ustring("dummy");
+}
+
+std::map<Glib::ustring, Glib::ustring> SetBGXFCE::get_active_displays()
+{
+    std::map<Glib::ustring, Glib::ustring> map_displays;
+
+    // @TODO: execute xfconf-query, listing keys in -c xfce4-desktop, extract screenX/monitorY entries (just use the monitors)
+
+    //map_displays[screen->make_display_name()] = ostr.str();
+
+    map_displays["dummy"] = "XFCE";
+    return map_displays;
+}
+
+Glib::ustring SetBGXFCE::get_fullscreen_key()
+{
+    return Glib::ustring("dummy");
+}
+
+Glib::ustring SetBGXFCE::get_prefix()
+{
+    Glib::ustring display("");
+    return display;
+}
+
+/**
+ * Returns if this background setter should be setting the Nitrogen configuration.
+ *
+ * The XFCE mode is completely external.
+ */
+bool SetBGXFCE::save_to_config()
 {
     return false;
 }

--- a/src/SetBG.cc
+++ b/src/SetBG.cc
@@ -1592,15 +1592,7 @@ bool SetBGPcmanfm::save_to_config()
  */
 
 bool SetBGXFCE::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode, Gdk::Color bgcolor) {
-    std::cerr << "SetBG for " << disp << "\n";
-    // set image
-    std::vector<std::string> params;
-    params.push_back(std::string("-s"));
-    params.push_back(std::string(file));
-
-    call_xfconf(disp, std::string("last-image"), params);
-
-    Glib::ustring strmode = "1"; //centered
+    Glib::ustring strmode = "1";
 	switch(mode) {
 		case SetBG::SET_CENTER:     strmode = "1"; break;
 		case SetBG::SET_TILE:       strmode = "2"; break;
@@ -1608,6 +1600,21 @@ bool SetBGXFCE::set_bg(Glib::ustring &disp, Glib::ustring file, SetMode mode, Gd
 		case SetBG::SET_ZOOM:       strmode = "4"; break;   // xfce calls this "scaled"
 		case SetBG::SET_ZOOM_FILL:  strmode = "5"; break;   // xfce calls this "zoomed"
 	};
+
+    if (disp == this->get_fullscreen_key()) {
+        // special handling for fullscreen:
+        // XFCE sets a new mode (value "6", labeled "Spanning Screens" in their config tool), and
+        // sets it on monitor0.  just tweak the params here and continue
+        disp    = std::string("0");
+        strmode = std::string("6");
+    }
+
+    // set image
+    std::vector<std::string> params;
+    params.push_back(std::string("-s"));
+    params.push_back(std::string(file));
+
+    call_xfconf(disp, std::string("last-image"), params);
 
     params.clear();
     params.push_back(std::string("-s"));

--- a/src/SetBG.h
+++ b/src/SetBG.h
@@ -198,4 +198,18 @@ class SetBGPcmanfm : public SetBGGnome {
         virtual Glib::ustring make_display_key(gint head);
 };
 
+class SetBGXFCE : public SetBG {
+    public:
+        virtual Glib::ustring get_fullscreen_key();
+        virtual std::map<Glib::ustring, Glib::ustring> get_active_displays();
+        virtual bool save_to_config();
+        virtual bool set_bg(Glib::ustring &disp,
+                            Glib::ustring file,
+                            SetMode mode,
+                            Gdk::Color bgcolor);
+    protected:
+        virtual Glib::ustring get_prefix();
+        virtual Glib::ustring make_display_key(gint head);
+};
+
 #endif

--- a/src/SetBG.h
+++ b/src/SetBG.h
@@ -210,6 +210,8 @@ class SetBGXFCE : public SetBG {
     protected:
         virtual Glib::ustring get_prefix();
         virtual Glib::ustring make_display_key(gint head);
+
+        bool call_xfconf(Glib::ustring disp, std::string key, const std::vector<std::string>& params);
 };
 
 #endif

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -97,7 +97,7 @@ ArgParser* create_arg_parser() {
     parser->register_option("sort", _("How to sort the backgrounds. Valid options are:\n\t\t\t* alpha, for alphanumeric sort\n\t\t\t* ralpha, for reverse alphanumeric sort\n\t\t\t* time, for last modified time sort (oldest first)\n\t\t\t* rtime, for reverse last modified time sort (newest first)"), true);
     parser->register_option("set-color", _("background color in hex, #000000 by default"), true);
     parser->register_option("head", _("Select xinerama/multihead display in GUI, 0..n, -1 for full"), true);
-    parser->register_option("force-setter", _("Force setter engine: xwindows, xinerama, gnome, pcmanfm"), true);
+    parser->register_option("force-setter", _("Force setter engine: xwindows, xinerama, gnome, pcmanfm, xfce"), true);
     parser->register_option("random", _("Choose random background from config or given directory"));
 
     // command line set modes

--- a/src/main.cc
+++ b/src/main.cc
@@ -163,6 +163,8 @@ int main (int argc, char ** argv) {
             setter = new SetBGGnome();
         else if (setter_str == "pcmanfm")
             setter = new SetBGPcmanfm();
+        else if (setter_str == "xfce")
+            setter = new SetBGXFCE();
         else
             setter = SetBG::get_bg_setter();
 


### PR DESCRIPTION
Fixes #121.

~~WIP - needs better detection of active monitors (xinerama likely for now), not just reading from XFCE configuration.  Using `--head` on the command line can grow that config and make nitrogen think there are more heads than actually exist.~~ Addressed in 0cb3033 / 0670288